### PR TITLE
make key mandatory for oembed

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,8 +29,13 @@ You can also specify additional parameters which are sent to the OEmbed
 provider too::
 
     Page.create_content_type(OembedContent, TYPE_CHOICES=TYPE_CHOICES,
-        PARAMS={'wmode': 'opaque', 'key': settings.EMBEDLY_KEY})
+        PARAMS={'wmode': 'opaque'})
 
+
+By default feincms_oembed uses the Embedly_ Oembed Provider. This provider
+requires an API key even for the free plan. ``settings.EMBEDLY_KEY`` must
+therefore be set.
+The free plan is good for 5000 URLs per month.
 
 If you want to customize the Embedly_ request or use another OEmbed provider,
 set ``settings.OEMBED_PROVIDER`` to a function receiving the URL and a dict

--- a/feincms_oembed/providers.py
+++ b/feincms_oembed/providers.py
@@ -1,12 +1,15 @@
 from django.utils.http import urlencode
+from django.conf import settings
 
 
 def embedly_oembed_provider(url, kwargs):
     """
     Provider for the oEmbed service at http://embed.ly/
+    Embedly requires an API key.
     """
     kwargs['url'] = url
-    return 'http://api.embed.ly/1/oembed?%s' % urlencode(kwargs)
+    kwargs['key'] = settings.EMBEDLY_KEY
+    return 'https://api.embed.ly/1/oembed?%s' % urlencode(kwargs)
 
 
 def noembed_oembed_provider(url, kwargs):


### PR DESCRIPTION
It is not possible anymore to use Embedly without an API-Key.